### PR TITLE
Sistema de Níveis dos players

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,5 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "Multiplayer Pong Project.sln"
+    "dotnet.defaultSolution": "Multiplayer-Pong-Project.sln"
 }

--- a/Assets/Scenes/Hugo/LustSkill - Test.unity
+++ b/Assets/Scenes/Hugo/LustSkill - Test.unity
@@ -514,8 +514,15 @@ MonoBehaviour:
   _isVulnerable: 1
   _isStunned: 0
   _isDead: 0
+  _stunVfxPrefab: {fileID: 0}
+  _stunOffset: {x: 0, y: 1.8, z: 0}
   _inputReader: {fileID: 1511679372}
   _abilityCooldown: 0
+  _level: 1
+  _hasShield: 0
+  _activeShieldVisual: {fileID: 0}
+  _shieldOffset: {x: 0, y: 1.8, z: 0}
+  _shieldVisualScale: {x: 0, y: 0, z: 0}
   _players:
   - {fileID: 2087440563}
   - {fileID: 0}
@@ -523,6 +530,11 @@ MonoBehaviour:
   - {fileID: 1511679371}
   _selectedTargetIndex: 0
   _isSelectingTarget: 0
+  _shieldVisualPrefab: {fileID: 0}
+  _shieldCount: 1
+  _selectionInputCooldown: 0.2
+  _selectionText: {fileID: 0}
+  _useDebug: 0
 --- !u!114 &1511679372 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6522086124894741760, guid: 8e8aa83f77d60b24b97a1aa308b3bba6, type: 3}
@@ -674,6 +686,11 @@ MonoBehaviour:
   _isVulnerable: 1
   _isStunned: 0
   _isDead: 0
+  _stunVfxPrefab: {fileID: 0}
+  _stunOffset: {x: 0, y: 1.8, z: 0}
+  _renderers: []
+  _normalColor: {r: 1, g: 1, b: 1, a: 1}
+  _stunnedColor: {r: 0, g: 1, b: 1, a: 1}
 --- !u!114 &2087440563 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 4603955107793656813, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
@@ -754,6 +771,14 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 4603955107793656813, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: _useDebug
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4603955107793656813, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: _bossPullDistance
+      value: 0.1
+      objectReference: {fileID: 0}
     - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0.8000002

--- a/Assets/Scenes/Hugo/SlothSkill-Test.unity
+++ b/Assets/Scenes/Hugo/SlothSkill-Test.unity
@@ -508,6 +508,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Fraud_Player Variant
       objectReference: {fileID: 0}
+    - target: {fileID: 7662102689985741703, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: _activeShieldVisual
+      value: 
+      objectReference: {fileID: 1918504192231109622, guid: 59eb93bab2040c642b13a21d1962a985, type: 3}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -524,6 +528,67 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6680b796858a5c04d8d7479e249234da, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &586004825
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4603955107793656813, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: _activeShieldVisual
+      value: 
+      objectReference: {fileID: 1918504192231109622, guid: 59eb93bab2040c642b13a21d1962a985, type: 3}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6.6957226
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -7.618249
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7474512790362384098, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7864121296518740194, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+      propertyPath: m_Name
+      value: Violence_Player Variant
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -573,6 +638,17 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1176015045 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4603955107793656813, guid: cfba0d379938102488c285751e1ba0ce, type: 3}
+  m_PrefabInstance: {fileID: 586004825}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 385011aed41cab148b89647dfee7938c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1650681493 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8168781483813912929, guid: 133588ec6bfb94a4288aaf4d5aec7078, type: 3}
@@ -803,6 +879,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 457156639}
     - target: {fileID: 1472597330758859331, guid: 41b9d1bf03757af4e951c3f2d3525094, type: 3}
+      propertyPath: '_players.Array.data[1]'
+      value: 
+      objectReference: {fileID: 1176015045}
+    - target: {fileID: 1472597330758859331, guid: 41b9d1bf03757af4e951c3f2d3525094, type: 3}
       propertyPath: '_players.Array.data[2]'
       value: 
       objectReference: {fileID: 1650681493}
@@ -940,3 +1020,4 @@ SceneRoots:
   - {fileID: 29837498}
   - {fileID: 1905326969}
   - {fileID: 457156638}
+  - {fileID: 586004825}

--- a/Assets/Scenes/Hugo/SlothSkill-Test.unity
+++ b/Assets/Scenes/Hugo/SlothSkill-Test.unity
@@ -456,6 +456,74 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 1
+--- !u!1001 &457156638
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1.6624203
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -6.8649654
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2746355803338865700, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3208024656542229028, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+      propertyPath: m_Name
+      value: Fraud_Player Variant
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+--- !u!114 &457156639 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7662102689985741703, guid: 4fa5b19b215441f4ab3907f00921ea7f, type: 3}
+  m_PrefabInstance: {fileID: 457156638}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6680b796858a5c04d8d7479e249234da, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &832575517
 GameObject:
   m_ObjectHideFlags: 0
@@ -505,17 +573,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1511679371 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 1472597330758859331, guid: 41b9d1bf03757af4e951c3f2d3525094, type: 3}
-  m_PrefabInstance: {fileID: 34655870333986349}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e35ba2c4be30e9e4984519cf716796a6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1650681493 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 8168781483813912929, guid: 133588ec6bfb94a4288aaf4d5aec7078, type: 3}
@@ -656,6 +713,11 @@ MonoBehaviour:
   _isVulnerable: 1
   _isStunned: 0
   _isDead: 0
+  _stunVfxPrefab: {fileID: 0}
+  _stunOffset: {x: 0, y: 1.8, z: 0}
+  _renderers: []
+  _normalColor: {r: 1, g: 1, b: 1, a: 1}
+  _stunnedColor: {r: 0, g: 1, b: 1, a: 1}
 --- !u!1 &1905326967
 GameObject:
   m_ObjectHideFlags: 0
@@ -685,8 +747,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1fe60edbad234494c91c297f34c970e2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _targetPlayer: {fileID: 1511679371}
-  _damage: 1
 --- !u!4 &1905326969
 Transform:
   m_ObjectHideFlags: 0
@@ -738,6 +798,10 @@ PrefabInstance:
       propertyPath: _shieldVisualScale.z
       value: 0.5
       objectReference: {fileID: 0}
+    - target: {fileID: 1472597330758859331, guid: 41b9d1bf03757af4e951c3f2d3525094, type: 3}
+      propertyPath: '_players.Array.data[0]'
+      value: 
+      objectReference: {fileID: 457156639}
     - target: {fileID: 1472597330758859331, guid: 41b9d1bf03757af4e951c3f2d3525094, type: 3}
       propertyPath: '_players.Array.data[2]'
       value: 
@@ -875,3 +939,4 @@ SceneRoots:
   - {fileID: 1814587805}
   - {fileID: 29837498}
   - {fileID: 1905326969}
+  - {fileID: 457156638}

--- a/Assets/Scenes/Hugo/ViolenceSkill - Test.unity
+++ b/Assets/Scenes/Hugo/ViolenceSkill - Test.unity
@@ -890,7 +890,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8168781483813912929, guid: 133588ec6bfb94a4288aaf4d5aec7078, type: 3}
       propertyPath: _maxEnemyTargets
-      value: 4
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8168781483813912929, guid: 133588ec6bfb94a4288aaf4d5aec7078, type: 3}
       propertyPath: _enemyStunDuration

--- a/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
@@ -10,6 +10,9 @@ namespace Pong.Gameplay.Player
         [SerializeField, Range(1, 4)] private int _copyCount = 1;
         [SerializeField] private Relic _relicPrefab;
 
+        [Header("Debug")]
+        [SerializeField] private bool _useDebug;
+
         public bool IsCopyModeActive => _isCopyModeActive;
 
         protected override void UseAbility()
@@ -33,6 +36,20 @@ namespace Pong.Gameplay.Player
             _copyCount = _level;
         }
 
+        private void Update()
+        {
+            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
+            {
+                LevelUp();
+                Debug.Log($"level: {_level} cópias: {_copyCount}");
+            }
+
+            if(Input.GetKeyDown(KeyCode.F2))
+            {
+                ActivateCopyMode();
+            }
+
+        }
         private void ActivateCopyMode()
         {
             _isCopyModeActive = true;

--- a/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
@@ -7,7 +7,7 @@ namespace Pong.Gameplay.Player
     {
         [Header("Ability")]
         [SerializeField] private bool _isCopyModeActive = false;
-        [SerializeField, Range(1, 4)] private int _copyCount = 1;
+        private int _copyCount = 1;
         [SerializeField] private Relic _relicPrefab;
 
         [Header("Debug")]
@@ -17,10 +17,8 @@ namespace Pong.Gameplay.Player
 
         protected override void UseAbility()
         {
-            Debug.Log($"CopyMode: {_isCopyModeActive}");
             if (_isCopyModeActive) return;
 
-            Debug.Log("Fraud is using ability.");
             ActivateCopyMode();
             StartCoroutine(AbilityCooldownRoutine());
         }
@@ -41,7 +39,6 @@ namespace Pong.Gameplay.Player
             if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
             {
                 LevelUp();
-                Debug.Log($"level: {_level} cópias: {_copyCount}");
             }
 
             if(Input.GetKeyDown(KeyCode.F2))
@@ -53,7 +50,6 @@ namespace Pong.Gameplay.Player
         private void ActivateCopyMode()
         {
             _isCopyModeActive = true;
-            Debug.Log($"{gameObject.name} activated relic copy mode.");
         }
 
         public void TryCopyRelic(Relic relic)
@@ -88,17 +84,16 @@ namespace Pong.Gameplay.Player
         private void ConsumeCopyMode()
         {
             _isCopyModeActive = false;
-            Debug.Log($"{gameObject.name} consumed relic copy mode.");
         }
 
         protected override void OnDamageTaken()
         {
-            Debug.Log($"{gameObject.name} took damage.");
+
         }
 
         protected override void OnDeath()
         {
-            Debug.Log($"{gameObject.name} died.");
+
         }
     }
 }

--- a/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
@@ -36,7 +36,7 @@ namespace Pong.Gameplay.Player
 
         private void Update()
         {
-            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
+            if(Input.GetKeyDown(KeyCode.F1) && _useDebug)
             {
                 LevelUp();
             }

--- a/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Fraud/Scripts/FraudPlayer.cs
@@ -14,11 +14,23 @@ namespace Pong.Gameplay.Player
 
         protected override void UseAbility()
         {
+            Debug.Log($"CopyMode: {_isCopyModeActive}");
             if (_isCopyModeActive) return;
 
             Debug.Log("Fraud is using ability.");
             ActivateCopyMode();
             StartCoroutine(AbilityCooldownRoutine());
+        }
+
+        protected override void LevelUp()
+        {
+            base.LevelUp();
+            UpgradeCopyCount();
+        }
+
+        private void UpgradeCopyCount()
+        {
+            _copyCount = _level;
         }
 
         private void ActivateCopyMode()

--- a/Assets/_Game/Gameplay/Player/Lust/Prefabs/LustProjectile.prefab
+++ b/Assets/_Game/Gameplay/Player/Lust/Prefabs/LustProjectile.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 3336654419205733801}
   - component: {fileID: 8037289407857997159}
   - component: {fileID: -8838223440848298406}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: LustProjectile
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -125,7 +125,6 @@ MonoBehaviour:
   _speed: 10
   _lifeTime: 2
   _pullDuration: 0.5
-  _stopDistanceFromPlayer: 1.5
 --- !u!54 &-8838223440848298406
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/_Game/Gameplay/Player/Lust/Scripts/LustPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Lust/Scripts/LustPlayer.cs
@@ -14,6 +14,9 @@ namespace Pong.Gameplay.Player.Lust
         [SerializeField, Range(0.1f, 5f)] private float _bossPullDistance = 1.5f;
         [SerializeField, Range(0.1f, 3f)] private float _stopDistanceFromPlayer = 1f;
 
+        [Header("Debug")]
+        [SerializeField] private bool _useDebug;
+
         protected override void UseAbility()
         {
             SpawnProjectile();
@@ -31,6 +34,15 @@ namespace Pong.Gameplay.Player.Lust
             _projectileCount = _level;
         }
 
+        private void Update()
+        {
+            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
+            {
+                LevelUp();
+                Debug.Log($"level: {_level} projectiles: {_projectileCount}");
+            }
+
+        }
 
         private void SpawnProjectile()
         {

--- a/Assets/_Game/Gameplay/Player/Lust/Scripts/LustPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Lust/Scripts/LustPlayer.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.PlayerLoop;
 
 namespace Pong.Gameplay.Player.Lust
 {
@@ -7,6 +8,7 @@ namespace Pong.Gameplay.Player.Lust
         [Header("Ability")]
         [SerializeField] private LustProjectile _projectilePrefab;
         [SerializeField] private Transform _projectileSpawnPoint;
+        [SerializeField] private int _projectileCount = 1;
 
         [Header("Balance Settings")]
         [SerializeField, Range(0.1f, 5f)] private float _bossPullDistance = 1.5f;
@@ -18,6 +20,18 @@ namespace Pong.Gameplay.Player.Lust
             StartCoroutine(AbilityCooldownRoutine());
         }
 
+        protected override void LevelUp()
+        {
+            base.LevelUp();
+            UpgradeProjectileCount();
+        }
+
+        private void UpgradeProjectileCount()
+        {
+            _projectileCount = _level;
+        }
+
+
         private void SpawnProjectile()
         {
             if (_projectilePrefab == null || _projectileSpawnPoint == null)
@@ -26,17 +40,21 @@ namespace Pong.Gameplay.Player.Lust
                 return;
             }
 
-            LustProjectile projectile = Instantiate(
+            for(int i = 0; i < _projectileCount; i++)
+            {
+                LustProjectile projectile = Instantiate(
                 _projectilePrefab,
                 _projectileSpawnPoint.position,
                 Quaternion.identity
-            );
+                );
 
-            projectile.Initialize(
+                projectile.Initialize(
                 this,
                 _bossPullDistance,
                 _stopDistanceFromPlayer
-            );
+                );
+            }
+
 
             Debug.Log($"{gameObject.name} fired attraction projectile.");
         }

--- a/Assets/_Game/Gameplay/Player/Lust/Scripts/LustPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Lust/Scripts/LustPlayer.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using UnityEngine.PlayerLoop;
 
 namespace Pong.Gameplay.Player.Lust
 {
@@ -8,7 +7,8 @@ namespace Pong.Gameplay.Player.Lust
         [Header("Ability")]
         [SerializeField] private LustProjectile _projectilePrefab;
         [SerializeField] private Transform _projectileSpawnPoint;
-        [SerializeField] private int _projectileCount = 1;
+        [SerializeField] private float _spreadAngle = 30f;
+        private int _projectileCount = 1;
 
         [Header("Balance Settings")]
         [SerializeField, Range(0.1f, 5f)] private float _bossPullDistance = 1.5f;
@@ -36,28 +36,31 @@ namespace Pong.Gameplay.Player.Lust
 
         private void Update()
         {
-            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
+            if(Input.GetKeyDown(KeyCode.F1) && _useDebug)
             {
                 LevelUp();
-                Debug.Log($"level: {_level} projectiles: {_projectileCount}");
             }
-
         }
 
         private void SpawnProjectile()
         {
             if (_projectilePrefab == null || _projectileSpawnPoint == null)
             {
-                Debug.LogWarning($"{gameObject.name} is missing projectile setup.");
                 return;
             }
 
             for(int i = 0; i < _projectileCount; i++)
             {
+                float angleStep = _projectileCount > 1 ? _spreadAngle / (_projectileCount - 1) : 0;
+                float angle = -_spreadAngle / 2 + angleStep * i;
+
+                Quaternion rotation = _projectileSpawnPoint.rotation * Quaternion.Euler(0,angle,0);
+
+
                 LustProjectile projectile = Instantiate(
                 _projectilePrefab,
                 _projectileSpawnPoint.position,
-                Quaternion.identity
+                rotation
                 );
 
                 projectile.Initialize(
@@ -66,19 +69,16 @@ namespace Pong.Gameplay.Player.Lust
                 _stopDistanceFromPlayer
                 );
             }
-
-
-            Debug.Log($"{gameObject.name} fired attraction projectile.");
         }
 
         protected override void OnDamageTaken()
         {
-            Debug.Log($"{gameObject.name} took damage.");
+
         }
 
         protected override void OnDeath()
         {
-            Debug.Log($"{gameObject.name} died.");
+
         }
     }
 }

--- a/Assets/_Game/Gameplay/Player/Lust/Scripts/LustProjectile.cs
+++ b/Assets/_Game/Gameplay/Player/Lust/Scripts/LustProjectile.cs
@@ -28,10 +28,13 @@ namespace Pong.Gameplay.Player.Lust
         {
             if (_isInitialized) return;
 
+
             _owner = owner;
             _bossPullDistance = bossPullDistance;
             _stopDistanceFromPlayer = stopDistanceFromPlayer;
             _isInitialized = true;
+
+            
 
             Destroy(gameObject, _lifeTime);
         }

--- a/Assets/_Game/Gameplay/Player/Scripts/PlayerActor.cs
+++ b/Assets/_Game/Gameplay/Player/Scripts/PlayerActor.cs
@@ -13,6 +13,9 @@ namespace Pong.Gameplay.Player
         [Header("Ability")]
         [SerializeField, Range(0f, 10f)] protected float _abilityCooldown;
 
+        [Header("Level")]
+        [SerializeField] protected int _level = 1;
+
         [Header("Shield")]
         [SerializeField] protected bool _hasShield = false;
         [SerializeField] protected GameObject _activeShieldVisual;
@@ -26,6 +29,12 @@ namespace Pong.Gameplay.Player
         protected override void Awake()
         {
             base.Awake();
+        }
+
+        protected virtual void LevelUp()
+        {
+            _level++;
+            _level = Mathf.Clamp( _level, 1, 4);
         }
 
         protected virtual void OnEnable()

--- a/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
@@ -14,7 +14,7 @@ namespace Pong.Gameplay.Player
 
         [Header("Shield Settings")]
         [SerializeField] private GameObject _shieldVisualPrefab;
-        [SerializeField] private int _shieldCount = 1;
+        private int _shieldCount = 1;
 
         [Header("Selection")]
         [SerializeField, Range(0.05f, 1f)] private float _selectionInputCooldown = 0.2f;
@@ -51,7 +51,6 @@ namespace Pong.Gameplay.Player
             if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
             {
                 LevelUp();
-                Debug.Log($"level: {_level} escudos: {_shieldCount}");
             }
 
         }
@@ -96,7 +95,6 @@ namespace Pong.Gameplay.Player
         {
             if (_players == null || _players.Length == 0)
             {
-                Debug.LogWarning($"{gameObject.name} has no players assigned.");
                 return;
             }
 
@@ -109,9 +107,6 @@ namespace Pong.Gameplay.Player
             }
 
             UpdateSelectionVisual();
-
-            Debug.Log($"{gameObject.name} entered selection mode.");
-            Debug.Log($"{gameObject.name} current target: {_players[_selectedTargetIndex].gameObject.name}");
         }
 
         private void ExitSelectionMode()
@@ -119,7 +114,6 @@ namespace Pong.Gameplay.Player
             _isSelectingTarget = false;
             UpdateSelectionVisual();
 
-            Debug.Log($"{gameObject.name} exited selection mode.");
         }
 
         private void HandleSelectionMove(Vector2 input)
@@ -155,7 +149,6 @@ namespace Pong.Gameplay.Player
             }
 
             UpdateSelectionVisual();
-            Debug.Log($"{gameObject.name} selected {_players[_selectedTargetIndex].gameObject.name}");
         }
 
         private void SelectRightTarget()
@@ -168,7 +161,6 @@ namespace Pong.Gameplay.Player
             }
 
             UpdateSelectionVisual();
-            Debug.Log($"{gameObject.name} selected {_players[_selectedTargetIndex].gameObject.name}");
         }
 
         private void ConfirmShield()
@@ -182,7 +174,6 @@ namespace Pong.Gameplay.Player
                 PlayerActor target = _players[index];
 
                 target.ReceiveShield(_shieldVisualPrefab);
-                Debug.Log($"{gameObject.name} granted shield to {target.gameObject.name}");
             }
             
             ExitSelectionMode();
@@ -215,12 +206,11 @@ namespace Pong.Gameplay.Player
 
         protected override void OnDamageTaken()
         {
-            Debug.Log($"{gameObject.name} took damage.");
+            
         }
 
         protected override void OnDeath()
         {
-            Debug.Log($"{gameObject.name} died.");
             ExitSelectionMode();
         }
     }

--- a/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
@@ -14,6 +14,7 @@ namespace Pong.Gameplay.Player
 
         [Header("Shield Settings")]
         [SerializeField] private GameObject _shieldVisualPrefab;
+        [SerializeField] private int _shieldCount = 1;
 
         [Header("Selection")]
         [SerializeField, Range(0.05f, 1f)] private float _selectionInputCooldown = 0.2f;
@@ -29,6 +30,32 @@ namespace Pong.Gameplay.Player
             {
                 _selectionText.gameObject.SetActive(false);
             }
+        }
+
+        protected override void LevelUp()
+        {
+            base.LevelUp();
+            UpgradeShieldCount();
+        }
+
+        private void UpgradeShieldCount()
+        {
+            _shieldCount = _level;
+        }
+
+        private void Update()
+        {
+            if(Input.GetKeyDown(KeyCode.F1))
+            {
+                LevelUp();
+                Debug.Log($"level: {_level} cópias: {_shieldCount}");
+            }
+
+            if(Input.GetKeyDown(KeyCode.S))
+            {
+                UseAbility();
+            }
+
         }
 
         protected override void OnEnable()
@@ -149,12 +176,17 @@ namespace Pong.Gameplay.Player
         private void ConfirmShield()
         {
             if (_players == null || _players.Length == 0) return;
+            int shieldsToAplly = _shieldCount;
 
-            PlayerActor selectedPlayer = _players[_selectedTargetIndex];
-            selectedPlayer.ReceiveShield(_shieldVisualPrefab);
+            for(int i = 0; i < shieldsToAplly; i++)
+            {
+                int index = (_selectedTargetIndex + i) % _players.Length;
+                PlayerActor target = _players[index];
 
-            Debug.Log($"{gameObject.name} granted shield to {selectedPlayer.gameObject.name}");
-
+                target.ReceiveShield(_shieldVisualPrefab);
+                Debug.Log($"{gameObject.name} granted shield to {target.gameObject.name}");
+            }
+            
             ExitSelectionMode();
             StartCoroutine(AbilityCooldownRoutine());
         }

--- a/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
@@ -43,21 +43,6 @@ namespace Pong.Gameplay.Player
             _shieldCount = _level;
         }
 
-        private void Update()
-        {
-            if(Input.GetKeyDown(KeyCode.F1))
-            {
-                LevelUp();
-                Debug.Log($"level: {_level} cópias: {_shieldCount}");
-            }
-
-            if(Input.GetKeyDown(KeyCode.S))
-            {
-                UseAbility();
-            }
-
-        }
-
         protected override void OnEnable()
         {
             base.OnEnable();

--- a/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
@@ -48,7 +48,7 @@ namespace Pong.Gameplay.Player
 
         private void Update()
         {
-            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
+            if(Input.GetKeyDown(KeyCode.F1) && _useDebug)
             {
                 LevelUp();
             }

--- a/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Sloth/Scripts/SlothPlayer.cs
@@ -20,6 +20,9 @@ namespace Pong.Gameplay.Player
         [SerializeField, Range(0.05f, 1f)] private float _selectionInputCooldown = 0.2f;
         [SerializeField] private TMP_Text _selectionText;
 
+        [Header("Debug")]
+        [SerializeField] private bool _useDebug;
+
         private bool _canChangeSelection = true;
 
         protected override void Awake()
@@ -41,6 +44,16 @@ namespace Pong.Gameplay.Player
         private void UpgradeShieldCount()
         {
             _shieldCount = _level;
+        }
+
+        private void Update()
+        {
+            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
+            {
+                LevelUp();
+                Debug.Log($"level: {_level} escudos: {_shieldCount}");
+            }
+
         }
 
         protected override void OnEnable()

--- a/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
@@ -10,6 +10,9 @@ namespace Pong.Gameplay.Player
         [SerializeField] private float _stunRadius = 5f;
         [SerializeField] private float _enemyStunDuration = 1f;
         [SerializeField] private float _bossStunDuration = 1f;
+
+        [Header("Debug")]
+        [SerializeField] private bool _useDebug;
         private int _maxEnemyTargets = 1;
 
         protected override void UseAbility()
@@ -27,10 +30,10 @@ namespace Pong.Gameplay.Player
         
         private void Update()
         {
-            if(Input.GetKeyDown(KeyCode.F1))
+            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
             {
                 LevelUp();
-                Debug.Log($"level: {_level} cópias: {_maxEnemyTargets}");
+                Debug.Log($"level: {_level} alvos max: {_maxEnemyTargets}");
             }
 
         }

--- a/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
@@ -19,6 +19,17 @@ namespace Pong.Gameplay.Player
             StartCoroutine(AbilityCooldownRoutine());
         }
 
+        protected override void LevelUp()
+        {
+            base.LevelUp();
+            UpgradeEnemyTargets();
+        }
+
+        private void UpgradeEnemyTargets()
+        {
+            _maxEnemyTargets = _level;
+        }
+
         private void StunTargets()
         {
             Collider[] hits = Physics.OverlapSphere(transform.position, _stunRadius);

--- a/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
@@ -10,7 +10,7 @@ namespace Pong.Gameplay.Player
         [SerializeField] private float _stunRadius = 5f;
         [SerializeField] private float _enemyStunDuration = 1f;
         [SerializeField] private float _bossStunDuration = 1f;
-        [SerializeField] private int _maxEnemyTargets = 1;
+        private int _maxEnemyTargets = 1;
 
         protected override void UseAbility()
         {
@@ -24,6 +24,17 @@ namespace Pong.Gameplay.Player
             base.LevelUp();
             UpgradeEnemyTargets();
         }
+        
+        private void Update()
+        {
+            if(Input.GetKeyDown(KeyCode.F1))
+            {
+                LevelUp();
+                Debug.Log($"level: {_level} cópias: {_maxEnemyTargets}");
+            }
+
+        }
+
 
         private void UpgradeEnemyTargets()
         {

--- a/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
@@ -29,7 +29,7 @@ namespace Pong.Gameplay.Player
         
         private void Update()
         {
-            if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
+            if(Input.GetKeyDown(KeyCode.F1) && _useDebug)
             {
                 LevelUp();
             }

--- a/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
+++ b/Assets/_Game/Gameplay/Player/Violence/Scripts/ViolencePlayer.cs
@@ -17,7 +17,6 @@ namespace Pong.Gameplay.Player
 
         protected override void UseAbility()
         {
-            Debug.Log($"Violence is using ability.");
             StunTargets();
             StartCoroutine(AbilityCooldownRoutine());
         }
@@ -33,7 +32,6 @@ namespace Pong.Gameplay.Player
             if(Input.GetKeyDown(KeyCode.F1) || _useDebug)
             {
                 LevelUp();
-                Debug.Log($"level: {_level} alvos max: {_maxEnemyTargets}");
             }
 
         }
@@ -58,15 +56,12 @@ namespace Pong.Gameplay.Player
 
                     enemy.ApplyStun(_enemyStunDuration);
                     stunnedEnemies++;
-
-                    Debug.Log($"{gameObject.name} stunned enemy {hit.gameObject.name}");
                     continue;
                 }
 
                 if (hit.TryGetComponent(out BossActor boss))
                 {
                     boss.ApplyStun(_bossStunDuration);
-                    Debug.Log($"{gameObject.name} stunned boss {hit.gameObject.name}");
                 }
             }
         }
@@ -79,12 +74,12 @@ namespace Pong.Gameplay.Player
 
         protected override void OnDamageTaken()
         {
-            Debug.Log($"{gameObject.name} took damage.");
+
         }
 
         protected override void OnDeath()
         {
-            Debug.Log($"{gameObject.name} died.");
+
         }
     }
 }

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -3,10 +3,11 @@
 --- !u!55 &1
 PhysicsManager:
   m_ObjectHideFlags: 0
-  serializedVersion: 13
+  serializedVersion: 18
   m_Gravity: {x: 0, y: -9.81, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 2
+  m_DefaultMaxDepenetrationVelocity: 10
   m_SleepThreshold: 0.005
   m_DefaultContactOffset: 0.01
   m_DefaultSolverIterations: 6
@@ -16,21 +17,20 @@ PhysicsManager:
   m_EnableAdaptiveForce: 0
   m_ClothInterCollisionDistance: 0.1
   m_ClothInterCollisionStiffness: 0.2
-  m_ContactsGeneration: 1
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-  m_AutoSimulation: 1
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffbfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_SimulationMode: 0
   m_AutoSyncTransforms: 0
   m_ReuseCollisionCallbacks: 1
+  m_InvokeCollisionCallbacks: 1
   m_ClothInterCollisionSettingsToggle: 0
   m_ClothGravity: {x: 0, y: -9.81, z: 0}
   m_ContactPairsMode: 0
   m_BroadphaseType: 0
-  m_WorldBounds:
-    m_Center: {x: 0, y: 0, z: 0}
-    m_Extent: {x: 250, y: 250, z: 250}
-  m_WorldSubdivisions: 8
   m_FrictionType: 0
   m_EnableEnhancedDeterminism: 0
-  m_EnableUnifiedHeightmaps: 1
+  m_ImprovedPatchFriction: 0
   m_SolverType: 0
   m_DefaultMaxAngularSpeed: 50
+  m_ScratchBufferChunkCount: 4
+  m_CurrentBackendId: 4072204805
+  m_FastMotionThreshold: 3.4028235e+38

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -3,12 +3,12 @@
 --- !u!19 &1
 Physics2DSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 4
+  serializedVersion: 6
   m_Gravity: {x: 0, y: -9.81}
   m_DefaultMaterial: {fileID: 0}
   m_VelocityIterations: 8
   m_PositionIterations: 3
-  m_VelocityThreshold: 1
+  m_BounceThreshold: 1
   m_MaxLinearCorrection: 0.2
   m_MaxAngularCorrection: 8
   m_MaxTranslationSpeed: 100
@@ -19,6 +19,7 @@ Physics2DSettings:
   m_LinearSleepTolerance: 0.01
   m_AngularSleepTolerance: 2
   m_DefaultContactOffset: 0.01
+  m_ContactThreshold: 0
   m_JobOptions:
     serializedVersion: 2
     useMultithreading: 0
@@ -38,19 +39,18 @@ Physics2DSettings:
     m_IslandSolverJointCostScale: 10
     m_IslandSolverBodiesPerJob: 50
     m_IslandSolverContactsPerJob: 50
-  m_AutoSimulation: 1
+  m_SimulationMode: 0
+  m_SimulationLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_MaxSubStepCount: 4
+  m_MinSubStepFPS: 30
+  m_UseSubStepping: 0
+  m_UseSubStepContacts: 0
   m_QueriesHitTriggers: 1
   m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 0
   m_AutoSyncTransforms: 0
-  m_AlwaysShowColliders: 0
-  m_ShowColliderSleep: 1
-  m_ShowColliderContacts: 0
-  m_ShowColliderAABB: 0
-  m_ContactArrowScale: 0.2
-  m_ColliderAwakeColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.7529412}
-  m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
-  m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
-  m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_GizmoOptions: 10
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffbfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -12,7 +12,7 @@ TagManager:
   - 
   - Water
   - UI
-  - 
+  - Lust Projectile
   - 
   - 
   - 


### PR DESCRIPTION
O sistema de níveis é implementado em cima do sistema de habilidades. O objetivo é só de fazer com que as habilidades escalem por meio do nível de cada player.

- Classe Player: 
- Adicionado método LevelUp
- Adicionada variável level

As classes que herdam de Player então vão fazer um override de levelUp, que farão também suas próprias ações

- Sloth: Em seu LevelUp adiciona mais um jogador possível para receber o escudo da habilidade por nível
- Fraud: Em seu LevelUp cria uma cópia adicional da relíquia para cada nível
- Violence: Em seu LevelUp "stuna" mais um inimigo para cada nível
- Lust: Em seu LevelUp adiciona mais um projétil na habilidade